### PR TITLE
Raise an error on timeout in wait_flushing

### DIFF
--- a/lib/sqrewdriver/client.rb
+++ b/lib/sqrewdriver/client.rb
@@ -171,7 +171,11 @@ module Sqrewdriver
 
     def wait_flushing(timeout = nil)
       zipped = Concurrent::Promises.zip_futures_on(@thread_pool, *@waiting_futures)
-      exceptions = zipped.reason(timeout)
+      unless zipped.wait(timeout)
+        raise Sqrewdriver::SendMessageTimeout
+      end
+
+      exceptions = zipped.reason
       raise Sqrewdriver::SendMessageErrors.new(exceptions) if exceptions
     end
 

--- a/lib/sqrewdriver/client.rb
+++ b/lib/sqrewdriver/client.rb
@@ -179,9 +179,9 @@ module Sqrewdriver
       raise Sqrewdriver::SendMessageErrors.new(exceptions) if exceptions
     end
 
-    def flush
+    def flush(timeout = nil)
       flush_async
-      wait_flushing
+      wait_flushing(timeout)
     end
 
     private

--- a/lib/sqrewdriver/errors.rb
+++ b/lib/sqrewdriver/errors.rb
@@ -18,4 +18,6 @@ module Sqrewdriver
       @failed = failed
     end
   end
+
+  class SendMessageTimeout < StandardError; end
 end


### PR DESCRIPTION
`Concurrent::Promises::Future#reason` returns nil if the specified timeout exceeds.
cf. [concurrent/promises.rb#L947-L961](https://github.com/ruby-concurrency/concurrent-ruby/blob/v1.1.5/lib/concurrent/promises.rb#L947-L961)

I think it is better `wait_flushing` raises another error on timeout.
I also added `timeout` argument to `flush`.