### PR TITLE
Fix Aws::SQS::Errors::TooManyEntriesInBatchRequest

### DIFF
--- a/lib/sqrewdriver/client.rb
+++ b/lib/sqrewdriver/client.rb
@@ -55,6 +55,10 @@ module Sqrewdriver
           @data << message
           @bytesize += size
         end
+
+        def size
+          @data.size
+        end
       end
 
       include MonitorMixin
@@ -77,7 +81,7 @@ module Sqrewdriver
 
         synchronize do
           @chunks << Chunk.new if @chunks.empty?
-          if @chunks.last.bytesize + add_size > MAX_PAYLOAD_SIZE
+          if @chunks.last.size == MAX_BATCH_SIZE || @chunks.last.bytesize + add_size > MAX_PAYLOAD_SIZE
             new_chunk = Chunk.new
             new_chunk.add(message, add_size)
             @chunks << new_chunk


### PR DESCRIPTION
This PR fixes Aws::SQS::Errors::TooManyEntriesInBatchRequest caused by the following code:

```ruby
require 'sqrewdriver'

client = Sqrewdriver::Client.new(queue_url: ENV['QUEUE_URL'])
100.times do
  client.send_message_buffered(message_body: 'a')
end
begin
  client.flush
rescue Sqrewdriver::SendMessageErrors => e
  e.errors.each do |error|
    next if error.nil?
    puts error
    puts error.backtrace.join("\n")
  end
end
```

```
Maximum number of entries per request are 10. You have sent 100.
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.48.3/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.48.3/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.48.3/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.48.3/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.48.3/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.48.3/lib/seahorse/client/plugins/response_target.rb:23:in `call'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.48.3/lib/seahorse/client/request.rb:70:in `send_request'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/aws-sdk-sqs-1.13.0/lib/aws-sdk-sqs/client.rb:1812:in `send_message_batch'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/sqrewdriver-b0fa5f322668/lib/sqrewdriver/client.rb:143:in `send_message_batch_with_retry'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/sqrewdriver-b0fa5f322668/lib/sqrewdriver/client.rb:122:in `block in send_first_chunk_async'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/promises.rb:1582:in `evaluate_to'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/promises.rb:1765:in `block in on_resolvable'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:348:in `run_task'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:337:in `block (3 levels) in create_worker'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `loop'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `block (2 levels) in create_worker'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `catch'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `block in create_worker'
```