### PR TITLE
Remove `queue_url` argument from #send_message_buffered

### DIFF
--- a/lib/sqrewdriver/client.rb
+++ b/lib/sqrewdriver/client.rb
@@ -34,8 +34,8 @@ module Sqrewdriver
     # If count of buffered messages exceed 10 or aggregate_messages_per
     # else if sum of message size exceeds 256KB,
     # send payload to SQS asynchronously.
-    def send_message_buffered(queue_url: nil, **params)
-      add_message_to_buffer(params)
+    def send_message_buffered(message)
+      add_message_to_buffer(message)
 
       if need_flush?
         flush_async
@@ -190,8 +190,8 @@ module Sqrewdriver
 
     private
 
-    def add_message_to_buffer(params)
-      @message_buffer << params
+    def add_message_to_buffer(message)
+      @message_buffer << message
     end
 
     def need_flush?
@@ -199,7 +199,7 @@ module Sqrewdriver
     end
 
     def send_first_chunk_async
-      future = @sending_buffer.send_first_chunk_async 
+      future = @sending_buffer.send_first_chunk_async
       @waiting_futures << future
       future.on_resolution_using(@thread_pool) do |fulfilled, value, reason|
         @waiting_futures.delete(future)

--- a/spec/sqrewdriver/client_spec.rb
+++ b/spec/sqrewdriver/client_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Sqrewdriver::Client, aggregate_failures: true do
 
   describe "#send_message_buffered" do
     it "add message to buffer" do
-      client.send_message_buffered(queue_url: queue_url, message_body: {foo: "body"})
+      client.send_message_buffered(message_body: {foo: "body"})
       buffer = client.instance_variable_get(:@message_buffer)
 
       expect(buffer[0]).to eq({message_body: {foo: "body"}})
@@ -20,7 +20,7 @@ RSpec.describe Sqrewdriver::Client, aggregate_failures: true do
         sqs.stub_data(:send_message_batch)
       })
       12.times do
-        client.send_message_buffered(queue_url: queue_url, message_body: {foo: "body"})
+        client.send_message_buffered(message_body: {foo: "body"})
       end
       Concurrent::Promises.zip_futures(*client.instance_variable_get(:@waiting_futures)).wait!
       buffer = client.instance_variable_get(:@message_buffer)
@@ -60,7 +60,7 @@ RSpec.describe Sqrewdriver::Client, aggregate_failures: true do
         100.times do
           pool.post do
             15.times do
-              client.send_message_buffered(queue_url: queue_url, message_body: "body")
+              client.send_message_buffered(message_body: "body")
             end
           end
         end
@@ -91,13 +91,13 @@ RSpec.describe Sqrewdriver::Client, aggregate_failures: true do
           sqs.stub_data(:send_message_batch)
         })
         99.times do
-          client.send_message_buffered(queue_url: queue_url, message_body: {foo: "body"})
+          client.send_message_buffered(message_body: {foo: "body"})
         end
         Concurrent::Promises.zip_futures(*client.instance_variable_get(:@waiting_futures)).wait!
         buffer = client.instance_variable_get(:@message_buffer)
         expect(buffer.size).to eq(99)
 
-        client.send_message_buffered(queue_url: queue_url, message_body: {foo: "body"})
+        client.send_message_buffered(message_body: {foo: "body"})
         Concurrent::Promises.zip_futures(*client.instance_variable_get(:@waiting_futures)).wait!
         buffer = client.instance_variable_get(:@message_buffer)
         expect(buffer).to be_empty
@@ -128,7 +128,7 @@ RSpec.describe Sqrewdriver::Client, aggregate_failures: true do
           100.times do
             pool.post do
               15.times do
-                client.send_message_buffered(queue_url: queue_url, message_body: "body")
+                client.send_message_buffered(message_body: "body")
               end
             end
 


### PR DESCRIPTION
I think `queue_url` argument is unused in `Client#send_message_buffered`.