### PR TITLE
Add critical section on shifting sending buffer chunk.

### DIFF
--- a/lib/sqrewdriver/client.rb
+++ b/lib/sqrewdriver/client.rb
@@ -117,7 +117,7 @@ module Sqrewdriver
 
       def send_first_chunk_async
         Concurrent::Promises.future_on(@thread_pool, @chunks) do |chunks|
-          sending = chunks.shift
+          sending = synchronize { chunks.shift }
           if sending
             sending.data.each_with_index do |params, idx|
               params[:id] = idx.to_s

--- a/spec/sqrewdriver/client_spec.rb
+++ b/spec/sqrewdriver/client_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe Sqrewdriver::Client, aggregate_failures: true do
       ])
     end
 
+    it "can avoid rase condition on sending buffer (brute force test)" do
+      num = 0
+      expect {
+        begin
+          100000.times { |i| num = i
+            client.send_message_buffered(message_body: {foo: "body"})
+          }
+        rescue => e
+          puts "Failed with #{e} at ##{num}th iteration"
+          raise
+        end
+      }.not_to raise_error
+    end
+
     context "multi thread" do
       it "can send all messages" do
         entries = []


### PR DESCRIPTION
`Client#send_message_buffered` potentially cause exception while `async_flush` by chunk of sending buffer becoming empty on enqueueing.

This patch adds synchronize section on shifting chunk.

Original version may fail with such error;
```
sugi@tempest:~/works/git/github/sqrewdriver% bundle exec rspec spec/sqrewdriver/client_spec.rb:56
Run options: include {:locations=>{"./spec/sqrewdriver/client_spec.rb"=>[56]}}

Sqrewdriver::Client
  #send_message_buffered
Failed with undefined method `add' for nil:NilClass at #88569th iteration
    can avoid rase condition on sending buffer (FAILED - 1)

Failures:

  1) Sqrewdriver::Client#send_message_buffered can avoid rase condition on sending buffer
     Failure/Error:
       expect {
         begin
           10000.times { |i| num = i
             client.send_message_buffered(message_body: {foo: "body"})
           }
         rescue => e
           puts "Failed with #{e} at ##{num}th iteration"
           raise
         end
       }.not_to raise_error
     
       expected no Exception, got #<NoMethodError: undefined method `add' for nil:NilClass> with backtrace:
         # ./lib/sqrewdriver/client.rb:89:in `block in add_message'
         # ./lib/sqrewdriver/client.rb:82:in `add_message'
         # ./lib/sqrewdriver/client.rb:165:in `flush_async'
         # ./lib/sqrewdriver/client.rb:41:in `send_message_buffered'
         # ./spec/sqrewdriver/client_spec.rb:57:in `block (5 levels) in <top (required)>'
         # ./spec/sqrewdriver/client_spec.rb:56:in `times'
         # ./spec/sqrewdriver/client_spec.rb:56:in `block (4 levels) in <top (required)>'
         # ./spec/sqrewdriver/client_spec.rb:54:in `block (3 levels) in <top (required)>'
     # ./spec/sqrewdriver/client_spec.rb:54:in `block (3 levels) in <top (required)>'

Finished in 15.01 seconds (files took 0.20373 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/sqrewdriver/client_spec.rb:52 # Sqrewdriver::Client#send_message_buffered can avoid rase condition on sending buffer
```