### PR TITLE
Improve message formatting of SendMessageErrors.

### DIFF
--- a/lib/sqrewdriver/errors.rb
+++ b/lib/sqrewdriver/errors.rb
@@ -3,11 +3,15 @@ module Sqrewdriver
     attr :errors
 
     def initialize(errors)
-      @errors = errors
+      @errors = Array(errors).compact
     end
 
     def messages
       @errors.map(&:message)
+    end
+
+    def to_s
+      errors.map(&:inspect).join(", ")
     end
   end
 


### PR DESCRIPTION
The current formatting of SendMessageErrors is useless because it just returns "Sqrewdriver::SendMessageErrors" always.

```
sugi@tempest:~/works/git/github/sqrewdriver% ./bin/console
2.6.2 :001 > e = Sqrewdriver::SendMessageErrors.new([StandardError.new("err1"), IndexError.new("e2")])
 => #<Sqrewdriver::SendMessageErrors: Sqrewdriver::SendMessageErrors>
2.6.2 :002 > e.message
 => "Sqrewdriver::SendMessageErrors"
2.6.2 :003 > e.to_s
 => "Sqrewdriver::SendMessageErrors"
```

This patch overrides `#to_s` to provide information of contained exceptions like following;

```
sugi@tempest:~/works/git/github/sqrewdriver% ./bin/console
2.6.2 :001 > e = Sqrewdriver::SendMessageErrors.new([StandardError.new("err1"), IndexError.new("e2")])
 => #<Sqrewdriver::SendMessageErrors: #<StandardError: err1>, #<IndexError: e2>>
2.6.2 :002 > e.message
 => "#<StandardError: err1>, #<IndexError: e2>"
2.6.2 :003 > e.to_s
 => "#<StandardError: err1>, #<IndexError: e2>"
```