### PR TITLE
Add Client#close method to avoid thread pool leak

### DIFF
--- a/spec/sqrewdriver/client_spec.rb
+++ b/spec/sqrewdriver/client_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe Sqrewdriver::Client, aggregate_failures: true do
       }.not_to raise_error
     end
 
+    it "raises error on closed client" do
+      expect {
+        client.send_message_buffered(message_body: {foo: "body"})
+      }.not_to raise_error
+
+      client.close
+      expect {
+        client.send_message_buffered(message_body: {foo: "body"})
+      }.to raise_error Sqrewdriver::ClientClosed
+    end
+
     context "multi thread" do
       it "can send all messages" do
         entries = []


### PR DESCRIPTION
The current implementation dose not provide a solution to shutdown the thread pool created by `Sqrewdriver::Client` internally.  Currently the thread pool created by the client instance is orphaned and abandoned until the interpreter exits.
As a result, memory usage increases with each new instance of `Sqrewdriver::Client`.

This patch adds `Client#close` method to intentionally shutdown the thread pool.
This will prevent users from a thread pool leak if they don't forget calling `#close`.

(If possible, I think it's best to shut down the thread pool automatically when the client instance is removed by GC. I'll send another PR later. #10 )

BTW, #7 introducing #7 without a thread pool outage seems to have the **opposite** effect on memory usage for non-singletons.

## Stats

I tested with ruby 2.6.2p47, localstack, jemalloc 5.2.1 and [this test script](https://gist.github.com/sugi/e64425698cdfe3c53e2ecbb5e2701bc2#file-sqrewdriver-thread-leak-test-rb).

### v0.1.2 + this patch (calling `#close`)

```
Runner started. Settings: threads=100, loop=10, msgs=50000, chunk_size=100
===> sqrewdriver send_message_buffered with thread pool shutdown
#1  Threads:    1, VSZ:   499.77MB  +430.23MB, RSS:   277.24MB  +244.82MB
#2  Threads:    1, VSZ:   535.27MB   +35.50MB, RSS:   270.71MB    -6.53MB
#3  Threads:    1, VSZ:   560.27MB   +25.00MB, RSS:   266.20MB    -4.51MB
#4  Threads:    1, VSZ:   571.27MB   +11.00MB, RSS:   261.70MB    -4.50MB
#5  Threads:    1, VSZ:   582.77MB   +11.50MB, RSS:   259.77MB    -1.93MB
#6  Threads:    1, VSZ:   585.77MB    +3.00MB, RSS:   254.86MB    -4.92MB
#7  Threads:    1, VSZ:   594.27MB    +8.50MB, RSS:   255.00MB    +0.15MB
#8  Threads:    1, VSZ:   596.77MB    +2.50MB, RSS:   256.02MB    +1.02MB
#9  Threads:    1, VSZ:   624.77MB   +28.00MB, RSS:   253.52MB    -2.50MB
#10 Threads:    1, VSZ:   627.27MB    +2.50MB, RSS:   252.40MB    -1.12MB
```

[full results](https://gist.github.com/sugi/e64425698cdfe3c53e2ecbb5e2701bc2#file-result-v0-1-2-close-patch-txt)

### current mater (incl. #7 ) + this patch (calling `#close`)

```
Runner started. Settings: threads=100, loop=10, msgs=50000, chunk_size=100
===> sqrewdriver send_message_buffered with thread pool shutdown
#1  Threads:    1, VSZ:   497.27MB  +427.73MB, RSS:   194.86MB  +166.25MB
#2  Threads:    1, VSZ:   510.27MB   +13.00MB, RSS:   183.26MB   -11.60MB
#3  Threads:    1, VSZ:   538.77MB   +28.50MB, RSS:   185.56MB    +2.30MB
#4  Threads:    1, VSZ:   543.77MB    +5.00MB, RSS:   183.33MB    -2.23MB
#5  Threads:    1, VSZ:   546.77MB    +3.00MB, RSS:   181.45MB    -1.89MB
#6  Threads:    1, VSZ:   549.27MB    +2.50MB, RSS:   185.75MB    +4.31MB
#7  Threads:    1, VSZ:   554.27MB    +5.00MB, RSS:   183.18MB    -2.57MB
#8  Threads:    1, VSZ:   556.77MB    +2.50MB, RSS:   180.12MB    -3.06MB
#9  Threads:    1, VSZ:   559.77MB    +3.00MB, RSS:   181.03MB    +0.91MB
#10 Threads:    1, VSZ:   567.77MB    +8.00MB, RSS:   180.73MB    -0.30MB
```

[full results](https://gist.github.com/sugi/e64425698cdfe3c53e2ecbb5e2701bc2#file-result-pr-7-close-patch-txt)

### v0.1.2

```
Runner started. Settings: threads=100, loop=10, msgs=50000, chunk_size=100
===> Normal sqrewdriver send_message_buffered (no thread pool shutdown)
#1  Threads:  101, VSZ:   592.05MB  +522.51MB, RSS:   269.31MB  +230.48MB
#2  Threads:  201, VSZ:   838.45MB  +246.39MB, RSS:   317.32MB   +48.01MB
#3  Threads:  301, VSZ:  1074.84MB  +236.39MB, RSS:   348.81MB   +31.49MB
#4  Threads:  401, VSZ:  1360.73MB  +285.89MB, RSS:   372.02MB   +23.21MB
#5  Threads:  501, VSZ:  1604.12MB  +243.39MB, RSS:   398.03MB   +26.02MB
#6  Threads:  601, VSZ:  1849.51MB  +245.39MB, RSS:   433.46MB   +35.43MB
#7  Threads:  701, VSZ:  2113.90MB  +264.39MB, RSS:   458.41MB   +24.95MB
#8  Threads:  801, VSZ:  2265.29MB  +151.39MB, RSS:   501.52MB   +43.11MB
#9  Threads:  901, VSZ:  2562.68MB  +297.39MB, RSS:   526.09MB   +24.57MB
#10 Threads: 1001, VSZ:  2910.57MB  +347.89MB, RSS:   553.04MB   +26.95MB
```

[full results](https://gist.github.com/sugi/e64425698cdfe3c53e2ecbb5e2701bc2#file-result-v0-1-2-txt)


### current mater (incl. #7 )

```
Runner started. Settings: threads=100, loop=10, msgs=50000, chunk_size=100
===> Normal sqrewdriver send_message_buffered (no thread pool shutdown)
#1  Threads:  101, VSZ:   598.05MB  +528.51MB, RSS:   204.00MB  +166.57MB
#2  Threads:  201, VSZ:   841.45MB  +243.39MB, RSS:   239.90MB   +35.91MB
#3  Threads:  301, VSZ:  1090.34MB  +248.89MB, RSS:   272.89MB   +32.99MB
#4  Threads:  401, VSZ:  1360.23MB  +269.89MB, RSS:   354.25MB   +81.36MB
#5  Threads:  501, VSZ:  1586.12MB  +225.89MB, RSS:   449.83MB   +95.57MB
#6  Threads:  601, VSZ:  1849.51MB  +263.39MB, RSS:   517.32MB   +67.49MB
#7  Threads:  701, VSZ:  2131.90MB  +282.39MB, RSS:   562.93MB   +45.62MB
#8  Threads:  801, VSZ:  2268.29MB  +136.39MB, RSS:   651.16MB   +88.23MB
#9  Threads:  901, VSZ:  2567.68MB  +299.39MB, RSS:   678.40MB   +27.24MB
#10 Threads: 1001, VSZ:  2714.07MB  +146.39MB, RSS:   763.54MB   +85.13MB
```

[full results](https://gist.github.com/sugi/e64425698cdfe3c53e2ecbb5e2701bc2#file-result-pr-7-txt)
